### PR TITLE
refactor: 1株当たりの価値グラフの表示を分割

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -65,7 +65,7 @@ def main():
                 )
             with cols[1]:
                 st.plotly_chart(
-                    plot_manager.create_per_share_chart(financial_data),
+                    plot_manager.create_shares_chart(financial_data),
                     use_container_width=True
                 )
 

--- a/src/app.py
+++ b/src/app.py
@@ -49,18 +49,28 @@ def main():
             plot_manager = PlotManager()
 
             # 業績確認グラフ
+            st.subheader("業績確認グラフ")
             st.plotly_chart(
                 plot_manager.create_performance_chart(financial_data),
                 use_container_width=True
             )
 
             # 1株当たりの価値グラフ
-            st.plotly_chart(
-                plot_manager.create_per_share_chart(financial_data),
-                use_container_width=True
-            )
+            st.subheader("1株当たりの価値グラフ")
+            cols = st.columns(2)
+            with cols[0]:
+                st.plotly_chart(
+                    plot_manager.create_per_share_chart(financial_data),
+                    use_container_width=True
+                )
+            with cols[1]:
+                st.plotly_chart(
+                    plot_manager.create_per_share_chart(financial_data),
+                    use_container_width=True
+                )
 
             # 稼ぐ力グラフ
+            st.subheader("稼ぐ力グラフ")
             st.plotly_chart(
                 plot_manager.create_earning_power_chart(financial_data),
                 use_container_width=True

--- a/src/plots/plot_manager.py
+++ b/src/plots/plot_manager.py
@@ -133,9 +133,24 @@ class PlotManager:
         config = ChartConfig(
             title="1株当たりの価値",
             y1_title="金額",
-            primary_data=primary_data,
-            y2_title="発行済株式数",
-            secondary_data={
+            primary_data=primary_data
+        )
+        
+        return PlotManager.create_financial_chart(data.dates, config)
+
+    @staticmethod
+    def create_shares_chart(data: FinancialDataModel) -> go.Figure:
+        """
+        発行済株式数チャートを作成
+        Args:
+            data (FinancialDataModel): 財務データモデル
+        Returns:
+            go.Figure: Plotlyのグラフオブジェクト
+        """
+        config = ChartConfig(
+            title="発行済株式数",
+            y1_title="株式数",
+            primary_data={
                 "発行済株式数": data.shares
             }
         )


### PR DESCRIPTION
Issue #15 の対応

- 1株当たりの価値グラフを2つに分割
- 左側にEPS/BPS/DPS、右側に発行済株式数を表示