### PR TITLE
feat: 1株当たりの価値グラフの改善

### DIFF
--- a/src/data/data_processor.py
+++ b/src/data/data_processor.py
@@ -77,23 +77,23 @@ class DataProcessor:
 
             # 配当データのタイムゾーンを統一
             dividends.index = dividends.index.tz_localize(None)
-            
+
             # 期間に応じて配当データを集計
             if period == PERIOD_QUARTERLY:
                 dps = dividends.resample("QE").sum()
             else:
                 # 年次の場合、各年の配当を合計
-                dps = dividends.groupby(pd.Grouper(freq="A")).sum()
-                
+                dps = dividends.resample("YE").sum()
+
             # インデックスを財務データに合わせる
             dps = dps.reindex(normalized_data["dates"], method="ffill")
-            
+
             # 配当データを追加
             if not dps.empty:
                 normalized_data["dps"] = dps.values
-                
+
             return normalized_data
-            
+
         except Exception as e:
             print(f"配当データの処理中にエラーが発生しました: {str(e)}")
             return normalized_data

--- a/src/data/data_processor.py
+++ b/src/data/data_processor.py
@@ -77,23 +77,23 @@ class DataProcessor:
 
             # 配当データのタイムゾーンを統一
             dividends.index = dividends.index.tz_localize(None)
-
+            
             # 期間に応じて配当データを集計
             if period == PERIOD_QUARTERLY:
                 dps = dividends.resample("QE").sum()
             else:
                 # 年次の場合、各年の配当を合計
-                dps = dividends.resample("YE").sum()
-
+                dps = dividends.groupby(pd.Grouper(freq="A")).sum()
+                
             # インデックスを財務データに合わせる
             dps = dps.reindex(normalized_data["dates"], method="ffill")
-
+            
             # 配当データを追加
             if not dps.empty:
                 normalized_data["dps"] = dps.values
-
+                
             return normalized_data
-
+            
         except Exception as e:
             print(f"配当データの処理中にエラーが発生しました: {str(e)}")
             return normalized_data

--- a/src/plots/plot_manager.py
+++ b/src/plots/plot_manager.py
@@ -48,8 +48,8 @@ class PlotManager:
                                 x=formatted_dates,
                                 y=values,
                                 name=name,
-                                mode="lines",
-                                fill="tozeroy",
+                                mode="lines+markers",  # マーカーを追加して変化点を明確に
+                                line={"shape": "hv"},  # 直線的な折れ線に変更
                                 yaxis="y2"
                             )
                         )
@@ -80,7 +80,8 @@ class PlotManager:
                 "yaxis2": {
                     "title": config.y2_title,
                     "overlaying": "y",
-                    "side": "right"
+                    "side": "right",
+                    "autorange": True  # 自動的に範囲を設定
                 }
             })
 

--- a/src/plots/plot_manager.py
+++ b/src/plots/plot_manager.py
@@ -133,7 +133,11 @@ class PlotManager:
         config = ChartConfig(
             title="1株当たりの価値",
             y1_title="金額",
-            primary_data=primary_data
+            primary_data=primary_data,
+            y2_title="株式数",
+            secondary_data={
+                "発行済株式数": data.shares
+            }
         )
         
         return PlotManager.create_financial_chart(data.dates, config)
@@ -147,13 +151,31 @@ class PlotManager:
         Returns:
             go.Figure: Plotlyのグラフオブジェクト
         """
-        config = ChartConfig(
-            title="発行済株式数",
-            y1_title="株式数",
-            primary_data={
-                "発行済株式数": data.shares
-            }
-        )
+        primary_data = {
+            "発行済株式数": data.shares
+        }
+        
+        # 配当データがある場合は追加
+        if data.dps is not None:
+            # 配当性向を計算（DPS / EPS * 100）
+            payout_ratio = [
+                (d / e * 100) if e != 0 else 0
+                for d, e in zip(data.dps, data.eps)
+            ]
+            
+            config = ChartConfig(
+                title="配当と配当性向",
+                y1_title="金額",
+                primary_data={"DPS": data.dps},
+                y2_title="配当性向 (%)",
+                secondary_data={"配当性向": payout_ratio}
+            )
+        else:
+            config = ChartConfig(
+                title="発行済株式数",
+                y1_title="株式数",
+                primary_data=primary_data
+            )
         
         return PlotManager.create_financial_chart(data.dates, config)
 


### PR DESCRIPTION
## 変更内容
1株当たりの価値グラフの改善を行いました。

### 1株当たりの価値グラフ
- 第2軸として発行済み株式数を追加
- 発行済み株式数は面グラフとして表示し、薄い補助的な色で表示

### 発行済み株式数グラフ
- DPSがある場合、グラフの内容を配当と配当性向の表示に変更
- DPSを第1軸の棒グラフとして表示
- 配当性向を第2軸の折れ線グラフとして表示
- DPSがない場合は従来通り発行済み株式数を表示

## 関連Issue
close #17