### PR TITLE
fix: 発行済株式数の時系列データ取得を修正 #23

### DIFF
--- a/src/data/data_fetcher.py
+++ b/src/data/data_fetcher.py
@@ -106,3 +106,35 @@ class DataFetcher:
         except Exception as e:
             print(f"配当データの取得に失敗しました: {str(e)}")
             return None
+
+    def get_shares_outstanding_history(self, period: str = PERIOD_QUARTERLY) -> Optional[pd.Series]:
+        """
+        発行済株式数の履歴を取得
+        Args:
+            period (str): "quarterly"（四半期）または"annual"（年次）
+        Returns:
+            Optional[pd.Series]: 発行済株式数の履歴
+        """
+        try:
+            # 貸借対照表から株式数を取得
+            balance = self.stock.balance_sheet if period == PERIOD_ANNUAL else self.stock.quarterly_balance_sheet
+            if balance.empty:
+                print(f"貸借対照表が取得できませんでした: {self.ticker}")
+                return None
+
+            # 株式数を取得（ShareIssued または CommonStockSharesOutstanding から）
+            shares = None
+            if "ShareIssued" in balance.index:
+                shares = balance.loc["ShareIssued"]
+            elif "CommonStockSharesOutstanding" in balance.index:
+                shares = balance.loc["CommonStockSharesOutstanding"]
+
+            if shares is None or shares.empty:
+                print(f"発行済株式数の履歴が取得できませんでした: {self.ticker}")
+                return None
+
+            return shares
+
+        except Exception as e:
+            print(f"発行済株式数の履歴の取得に失敗しました: {str(e)}")
+            return None

--- a/src/data/data_processor.py
+++ b/src/data/data_processor.py
@@ -56,8 +56,15 @@ class DataProcessor:
                 print(f"以下の項目が取得できませんでした: {', '.join(missing_items)}")
                 return None
 
-            # 株式数の設定
-            data["発行済株式数"] = pd.Series([shares] * len(data["売上高"].index), index=data["売上高"].index)
+            # 株式数の設定（各時点の値を取得）
+            shares_data = self.data_fetcher.get_shares_outstanding_history(period)
+            if shares_data is None:
+                print("株式数の履歴データが取得できませんでした")
+                return None
+            
+            # 株式数データのインデックスをfinancial dataのインデックスに合わせる
+            shares_data = shares_data.reindex(data["売上高"].index, method="ffill")
+            data["発行済株式数"] = shares_data
 
             # データフレームに変換
             df = pd.DataFrame(data)


### PR DESCRIPTION
## 概要
Issue #23 の不具合を修正しました。

## 修正内容
1. `DataProcessor`クラスの`process_financial_data`メソッドを修正
   - 各時点の発行済株式数を取得するように変更
   - 取得したデータを財務データのインデックスに合わせて整形

2. `DataFetcher`クラスに`get_shares_outstanding_history`メソッドを追加
   - 貸借対照表から時系列の発行済株式数データを取得
   - ShareIssued または CommonStockSharesOutstanding から株式数を取得

## 期待される動作
- 年次データ: 年度末時点の発行済株式数を表示
- 四半期データ: 四半期末時点の発行済株式数を表示
- 時系列での株式数の変化が正確に反映される

## テスト方法
1. 年次データでの確認
   - アプリケーションで銘柄を選択
   - 年次データを表示
   - 各年度末時点の株式数が正しく表示されることを確認

2. 四半期データでの確認
   - アプリケーションで銘柄を選択
   - 四半期データを表示
   - 各四半期末時点の株式数が正しく表示されることを確認